### PR TITLE
Workflow update to make not-noarch

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   build:
     uses: sot/skare3/.github/workflows/package_build.yml@master
-    with:
-      noarch: true
     secrets:
       CONDA_PASSWORD: ${{ secrets.CONDA_PASSWORD }}
       CHANDRA_XRAY_TOKEN: ${{ secrets.CHANDRA_XRAY_TOKEN }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -10,8 +10,6 @@ on:
 jobs:
   build:
     uses: sot/skare3/.github/workflows/package_build.yml@master
-    with:
-      noarch: true
     secrets:
       CONDA_PASSWORD: ${{ secrets.CONDA_PASSWORD }}
       CHANDRA_XRAY_TOKEN: ${{ secrets.CHANDRA_XRAY_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author="Jean Connelly",
     description="Show schedules and events in a web page",
     author_email="jconnelly@cfa.harvard.edu",
-    url="https://sot.github.io/schedule_view",
+    url="https://sot.github.io/schedule_view3",
     use_scm_version=True,
     setup_requires=["setuptools_scm", "setuptools_scm_git_archive"],
     zip_safe=False,


### PR DESCRIPTION
## Description

Workflow update to make not-noarch

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes issue that schedule_view3 wasn't built for osx and the non-fsds environment yaml file could not install all non-fsds packages.

This still won't *work* if not on HEAD because it just reads files from /proj/sot .

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
