### PR TITLE
Use get_cmds imported at kadi.commands level

### DIFF
--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -134,7 +134,7 @@ def get_page_entries(start_time):
     """
 
     # Get kadi dynamic commands from start_time
-    cmds = kc.commands.get_cmds(start=start_time)
+    cmds = kc.get_cmds(start=start_time)
     ok = (
         (cmds["type"] == "LOAD_EVENT")
         & (cmds["tlmsid"] == "None")


### PR DESCRIPTION
## Description
Use get_cmds imported at kadi.commands level

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes 
```
############################################################
 schedule_view_update_page --outdir /proj/sot/ska3/flight/www/ASPECT/schedule_view3
############################################################
<<2024-May-13 13:51>> Traceback (most recent call last):
<<2024-May-13 13:51>>   File "/proj/sot/ska3/flight/bin/schedule_view_update_page", line 10, in <module>
<<2024-May-13 13:51>>     sys.exit(main())
<<2024-May-13 13:51>>              ^^^^^^
<<2024-May-13 13:51>>   File "/proj/sot/ska3/flight/lib/python3.11/site-packages/schedule_view/schedule_view.py", line 257, in main
<<2024-May-13 13:51>>     entries = get_page_entries(start_time)
<<2024-May-13 13:51>>               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<<2024-May-13 13:51>>   File "/proj/sot/ska3/flight/lib/python3.11/site-packages/schedule_view/schedule_view.py", line 137, in get_page_entries
<<2024-May-13 13:51>>     cmds = kc.commands.get_cmds(start=start_time)
<<2024-May-13 13:51>>            ^^^^^^^^^^^
<<2024-May-13 13:51>> AttributeError: module 'kadi.commands' has no attribute 'commands'. Did you mean: 'commands_v2'?
```
This was an API change introduced by kadi https://github.com/sot/kadi/pull/328

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I confirmed the script runs and makes output now in a ska3 with kadi > 7.10 (I used masters 7.10.1.dev1+g978068e) .
