### PR TITLE
Use get_rltt_cmd, get_scheduled_stop_time_cmd, and annotated sched stop time

### DIFF
--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -180,12 +180,17 @@ def get_page_entries(start_time):
         if sst_cmd is not None:
             # the date of the schedule stop time is the later of the sst date or
             # the original sst
-            sst_date = sst_cmd["params"].get("scheduled_stop_time_orig", sst_cmd["date"])
+            sst_date = sst_cmd["params"].get(
+                "scheduled_stop_time_orig", sst_cmd["date"]
+            )
             entry["sched_stop"] = sst_date
         if "rltt" in entry and "sched_stop" in entry:
-            other_cmds = cmds[(cmds["date"] > entry["rltt"]) & (cmds["date"] < entry["sched_stop"])]
+            other_cmds = cmds[
+                (cmds["date"] > entry["rltt"]) & (cmds["date"] < entry["sched_stop"])
+            ]
             other_events = events_flight[
-                (events_flight["date"] > entry["rltt"]) & (events_flight["date"] < entry["sched_stop"])
+                (events_flight["date"] > entry["rltt"])
+                & (events_flight["date"] < entry["sched_stop"])
             ]
             if len(other_cmds) == 0 and len(other_events) == 0:
                 entry["status"] = "Ran nominally"

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -178,8 +178,10 @@ def get_page_entries(start_time):
         entry["date"] = rltt_cmd["date"]
         sst_cmd = cmds_week.get_scheduled_stop_time_cmd()
         if sst_cmd is not None:
-            # the date of the schedule stop time is the later of the sst date or
-            # the original sst
+            # If scheduled_stop_time_orig param exists, use that, otherwise
+            # use the date of the scheduled_stop_time command.  This code should
+            # work with commands that pre-date https://github.com/sot/kadi/pull/364
+            # and with commands after that PR (which introduced the scheduled_stop_time_orig param).
             sst_date = sst_cmd["params"].get(
                 "scheduled_stop_time_orig", sst_cmd["date"]
             )

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -168,25 +168,24 @@ def get_page_entries(start_time):
         mp_comment = get_mp_comment(week, mp_dat)
         if mp_comment is not None:
             entry["mp_comment"] = mp_comment
-        rltt_match = (cmds["source"] == week) & (
-            cmds["params"] == {"event_type": "RUNNING_LOAD_TERMINATION_TIME"}
-        )
-        if any(rltt_match):
-            rltt = cmds["date"][rltt_match][0]
-            entry["rltt"] = rltt
-            entry["date"] = rltt
-        else:
+        cmds_week = cmds[cmds["source"] == week]
+        rltt_cmd = cmds_week.get_rltt_cmd()
+        if rltt_cmd is None:
+            # This should just happen in the case when the start time is after rltt
+            # for the first "source" in run_loads
             continue
-        ss_match = (cmds["source"] == week) & (
-            cmds["params"] == {"event_type": "SCHEDULED_STOP_TIME"}
-        )
-        if any(ss_match):
-            ss = cmds["date"][ss_match][0]
-            entry["sched_stop"] = ss
+        entry["rltt"] = rltt_cmd["date"]
+        entry["date"] = rltt_cmd["date"]
+        sst_cmd = cmds_week.get_scheduled_stop_time_cmd()
+        if sst_cmd is not None:
+            # the date of the schedule stop time is the later of the sst date or
+            # the original sst
+            sst_date = sst_cmd["params"].get("scheduled_stop_time_orig", sst_cmd["date"])
+            entry["sched_stop"] = sst_date
         if "rltt" in entry and "sched_stop" in entry:
-            other_cmds = cmds[(cmds["date"] > rltt) & (cmds["date"] < ss)]
+            other_cmds = cmds[(cmds["date"] > entry["rltt"]) & (cmds["date"] < entry["sched_stop"])]
             other_events = events_flight[
-                (events_flight["date"] > rltt) & (events_flight["date"] < ss)
+                (events_flight["date"] > entry["rltt"]) & (events_flight["date"] < entry["sched_stop"])
             ]
             if len(other_cmds) == 0 and len(other_events) == 0:
                 entry["status"] = "Ran nominally"


### PR DESCRIPTION
Use get_rltt_cmd, get_scheduled_stop_time_cmd, and annotated sched stop time.

This is a quick update to support the changes in kadi states from https://github.com/sot/kadi/pull/364

That PR refines the methods (get_rltt_cmd, get_scheduled_stop_time_cmd) and changes how schedule stop time commands are handled for schedules that are truncated for replan.  Going forward, schedule stop times will have their dates moved to the RLTT of the interrupting schedule - but be annotated in the parameters to include the original date/time.

As schedule_view3 uses the intended original schedule stop time to help to determine if a week "ran nominally" this includes changes to support that.

## Requirements
- https://github.com/sot/kadi/pull/364 (uses the new methods)

## Interface impacts
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Output at https://icxc.cfa.harvard.edu/aspect/test_review_outputs/schedule_view3/pr6/index.html 
looks reasonable
```
(ska3-latest) jeanconn-kady> python schedule_view/schedule_view.py --outdir /proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/schedule_view3/pr6
(ska3-latest) jeanconn-kady> python -c "import kadi; print(kadi.__version__)"
7.17.4
(ska3-latest) jeanconn-kady> git rev-parse HEAD
f1aa3d65ea1e54699f15b2494d95b3b0e08fa6af
```