### PR TITLE
Update links to 'SOT MP Week', 'FOT MP dir', 'Starcheck'

### DIFF
--- a/schedule_view/index_template.html
+++ b/schedule_view/index_template.html
@@ -33,6 +33,8 @@
 <TABLE BORDER=1 style="width:100%">
 <TR>
 <TH>Schedule</TH>
+<TH>FOT Week</TH>
+<TH>Starcheck</TH>
 <TH>Date or RLTT</TH>
 <TH>Schedule Stop</TH>
 <TH>Event</TH>
@@ -43,7 +45,9 @@
 
 {% for entry in entries %}
 <TR>
-<TD align='center'><A HREF="{{ entry.get('starcheck_url')}}" target="_blank">{{ entry.get('products', '') }}</A></TD>
+<TD align='center'><A HREF="{{ entry.get('mp_url')}}" target="_blank">{{ entry.get('products', '') }}</A></TD>
+<TD align='center'><A HREF="{{ entry.get('fot_week_url')}}" target="_blank">FOT</A></TD></TR>
+<TD align='center'><A HREF="{{ entry.get('starcheck_url')}}" target="_blank">SC</A></TD>
 <TD align="right">{{ entry.get('date', '') }}</TD>
 <TD align="right" style='color:{{entry.get('ss_color')}}'>{{ entry.get('sched_stop', '') }}</TD>
 <TD>{{ entry.get('Event', '') }}</TD>

--- a/schedule_view/index_template.html
+++ b/schedule_view/index_template.html
@@ -45,9 +45,16 @@
 
 {% for entry in entries %}
 <TR>
-<TD align='center'><A HREF="{{ entry.get('mp_url')}}" target="_blank">{{ entry.get('products', '') }}</A></TD>
-<TD align='center'><A HREF="{{ entry.get('fot_week_url')}}" target="_blank">FOT</A></TD>
-<TD align='center'><A HREF="{{ entry.get('starcheck_url')}}" target="_blank">SC</A></TD>
+
+{% if entry.get('products') %}
+    <TD align='center'><A HREF="{{ entry.get('mp_url')}}" target="_blank">{{ entry.get('products', '') }}</A></TD>
+    <TD align='center'><A HREF="{{ entry.get('fot_week_url')}}" target="_blank">FOT</A></TD>
+    <TD align='center'><A HREF="{{ entry.get('starcheck_url')}}" target="_blank">SC</A></TD>
+{% else %}
+    <TD align='center'></TD>
+    <TD align='center'></TD>
+    <TD align='center'></TD>
+{% endif %}
 <TD align="right">{{ entry.get('date', '') }}</TD>
 <TD align="right" style='color:{{entry.get('ss_color')}}'>{{ entry.get('sched_stop', '') }}</TD>
 <TD>{{ entry.get('Event', '') }}</TD>

--- a/schedule_view/index_template.html
+++ b/schedule_view/index_template.html
@@ -46,7 +46,7 @@
 {% for entry in entries %}
 <TR>
 <TD align='center'><A HREF="{{ entry.get('mp_url')}}" target="_blank">{{ entry.get('products', '') }}</A></TD>
-<TD align='center'><A HREF="{{ entry.get('fot_week_url')}}" target="_blank">FOT</A></TD></TR>
+<TD align='center'><A HREF="{{ entry.get('fot_week_url')}}" target="_blank">FOT</A></TD>
 <TD align='center'><A HREF="{{ entry.get('starcheck_url')}}" target="_blank">SC</A></TD>
 <TD align="right">{{ entry.get('date', '') }}</TD>
 <TD align="right" style='color:{{entry.get('ss_color')}}'>{{ entry.get('sched_stop', '') }}</TD>

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -120,8 +120,6 @@ def get_mp_cycle(week, mp_scheds):
     mp_match = (mp_scheds["Week"] == mp_week) & (mp_scheds["Version"] == week[7])
     if np.any(mp_match):
         return mp_scheds[mp_match]["cycle_number"][0]
-    else:
-        raise ValueError
 
 
 def get_mp_comment(week, mp_scheds):

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -75,10 +75,7 @@ def get_mp_scheds(files):
     for sched_file in files:
         # First I want to read the cycle name which can be found in the first <H1> tag
         # like "<h1 align="center"> AO26 CXC Observing Schedules </h1>"
-        html = sched_file.read_text()
-        cycle_number = extract_cycle_number(html)
         tab = Table.read(sched_file, header_start=0, data_start=1)
-        tab["cycle_number"] = cycle_number
         # If all the comments are empty or masked, replace with emtpy string
         if np.all(tab["Comment"].mask):
             tab.remove_column("Comment")
@@ -98,7 +95,6 @@ def get_mp_scheds(files):
         h1_text = extract_h1_text(html)
         cycle_number = extract_cycle_number(h1_text)
         tab["cycle_number"] = cycle_number
-
         # Just keep the comments the week and cycle_number, and flip sort so it is ascending
         dat.append(tab["Week", "Version", "cycle_number", "Comment"][::-1])
     out = vstack(dat)
@@ -227,11 +223,11 @@ def get_page_entries(start_time):
     ok = events_flight["date"] > start_time
     events_flight = events_flight[ok]
 
-    # Get SOT MP comments
+    # Get SOT MP comments and weeks
     sched_files = get_sched_files()
     mp_dat = get_mp_scheds(sched_files)
 
-    # For the set of approved loads, add a dictionary for each to a list of entries for the
+    # For the set of run loads, add a dictionary for each to a list of entries for the
     # output table. Check if there are command events / nonload commands between rltt and
     # schedule_stop to get a quick idea about if the schedule was interrupted, and if so
     # update a key in the dictionary with that information.
@@ -241,9 +237,7 @@ def get_page_entries(start_time):
         mp_comment = get_mp_comment(week, mp_dat)
         if mp_comment is not None:
             entry["mp_comment"] = mp_comment
-        cycle = get_mp_cycle(week, mp_dat)
-        if cycle is not None:
-            entry["cycle"] = cycle
+        entry["cycle"] = get_mp_cycle(week, mp_dat)
         cmds_week = cmds[cmds["source"] == week]
         rltt_cmd = cmds_week.get_rltt_cmd()
         if rltt_cmd is None:
@@ -297,7 +291,7 @@ def get_page_entries(start_time):
                     "products": entry["Params"],
                     "Event": entry["Event"],
                     "Comment": entry["Comment"],
-                    "cycle": entry.get("cycle"),
+                    "cycle": get_mp_cycle(entry["Params"], mp_dat),
                 }
             )
             mp_comment = get_mp_comment(entry["Params"], mp_dat)
@@ -325,9 +319,10 @@ def get_page_entries(start_time):
     # Update the entries with defined weeks to have links to starcheck.
     for entry in entries:
         if "products" in entry:
-            entry["mp_url"] = (
-                f"https://icxc.harvard.edu/mp/schedules/cycle{entry['cycle']}/{entry['products']}.html"
-            )
+            if entry["cycle"] is not None:
+                entry["mp_url"] = (
+                    f"https://icxc.harvard.edu/mp/schedules/cycle{entry['cycle']}/{entry['products']}.html"
+                )
             entry["starcheck_url"] = get_starcheck_url(entry["products"])
             entry["fot_week_url"] = get_fot_week_url(entry["products"])
 

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -326,7 +326,7 @@ def get_page_entries(start_time):
     for entry in entries:
         if "products" in entry:
             entry["mp_url"] = (
-                f"https://icxc.harvard.edu/mp/schedules/cycle{entry["cycle"]}/{entry["products"]}.html"
+                f"https://icxc.harvard.edu/mp/schedules/cycle{entry['cycle']}/{entry['products']}.html"
             )
             entry["starcheck_url"] = get_starcheck_url(entry["products"])
             entry["fot_week_url"] = get_fot_week_url(entry["products"])

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 from pathlib import Path
 
 import kadi.commands as kc
@@ -7,6 +8,7 @@ from astropy.table import Table, vstack
 from jinja2 import Template
 from kadi import paths
 from mica.utils import load_name_to_mp_dir
+from parse_cm.paths import parse_load_name
 
 TEMPLATE = Path(__file__).parent / "index_template.html"
 
@@ -56,9 +58,27 @@ def get_mp_scheds(files):
         A table with the columns "Week", "Version", and "Comment" with the
         entries from the SOT MP schedule tables.
     """
+
+    def extract_cycle_number(h1_text):
+        match = re.search(r"AO(\d+)", h1_text)
+        if match:
+            return match.group(1)
+        return None
+
+    def extract_h1_text(html):
+        match = re.search(r"<h1[^>]*>(.*?)</h1>", html, re.IGNORECASE | re.DOTALL)
+        if match:
+            return match.group(1).strip()
+        return None
+
     dat = []
     for sched_file in files:
+        # First I want to read the cycle name which can be found in the first <H1> tag
+        # like "<h1 align="center"> AO26 CXC Observing Schedules </h1>"
+        html = sched_file.read_text()
+        cycle_number = extract_cycle_number(html)
         tab = Table.read(sched_file, header_start=0, data_start=1)
+        tab["cycle_number"] = cycle_number
         # If all the comments are empty or masked, replace with emtpy string
         if np.all(tab["Comment"].mask):
             tab.remove_column("Comment")
@@ -72,11 +92,40 @@ def get_mp_scheds(files):
             if row["Week"] is not None:
                 week_name = row["Week"]
 
-        # Just keep the comments and the week, and flip sort so it is ascending
-        dat.append(tab["Week", "Version", "Comment"][::-1])
+        # Read the cycle number which can be found in the first <H1> tag
+        # like "<h1 align="center"> AO26 CXC Observing Schedules </h1>"
+        html = sched_file.read_text()
+        h1_text = extract_h1_text(html)
+        cycle_number = extract_cycle_number(h1_text)
+        tab["cycle_number"] = cycle_number
 
+        # Just keep the comments the week and cycle_number, and flip sort so it is ascending
+        dat.append(tab["Week", "Version", "cycle_number", "Comment"][::-1])
     out = vstack(dat)
     return out
+
+
+def get_mp_cycle(week, mp_scheds):
+    """
+    Get the AO cycle for week.
+
+    Parameters
+    ----------
+    week : str
+        The week string, e.g. "FEB2324A"
+    mp_scheds : astropy.table.Table
+        The table of SOT MP schedules from get_mp_scheds.
+
+    Returns
+    -------
+    cycle : str or None
+    """
+    mp_week = week[0:7]
+    mp_match = (mp_scheds["Week"] == mp_week) & (mp_scheds["Version"] == week[7])
+    if np.any(mp_match):
+        return mp_scheds[mp_match]["cycle_number"][0]
+    else:
+        raise ValueError
 
 
 def get_mp_comment(week, mp_scheds):
@@ -98,6 +147,30 @@ def get_mp_comment(week, mp_scheds):
     mp_match = (mp_scheds["Week"] == mp_week) & (mp_scheds["Version"] == week[7])
     if np.any(mp_match):
         return mp_scheds[mp_match]["Comment"][0]
+
+
+def get_fot_week_url(week):
+    """
+    Construct URL for FOT week page.
+
+    Parameters
+    ----------
+    week : str
+        The week string, e.g. "FEB2324A"
+
+    Returns
+    -------
+    url : str
+
+    """
+    # Make something like https://occweb.cfa.harvard.edu/occweb/FOT/mission_planning/PRODUCTS/APPR_LOADS/2024/MAR/MAR2624A/
+    mon, _, _, _, year = parse_load_name(week)
+    # load_info is a tuple Returns a tuple with (mon, day, yr, rev, year)
+    approved_loads_url = (
+        "https://occweb.cfa.harvard.edu/occweb/FOT/mission_planning/PRODUCTS/APPR_LOADS"
+    )
+    url = f"{approved_loads_url}/{year}/{mon}/{week}/"
+    return url
 
 
 def get_starcheck_url(week):
@@ -168,6 +241,9 @@ def get_page_entries(start_time):
         mp_comment = get_mp_comment(week, mp_dat)
         if mp_comment is not None:
             entry["mp_comment"] = mp_comment
+        cycle = get_mp_cycle(week, mp_dat)
+        if cycle is not None:
+            entry["cycle"] = cycle
         cmds_week = cmds[cmds["source"] == week]
         rltt_cmd = cmds_week.get_rltt_cmd()
         if rltt_cmd is None:
@@ -221,6 +297,7 @@ def get_page_entries(start_time):
                     "products": entry["Params"],
                     "Event": entry["Event"],
                     "Comment": entry["Comment"],
+                    "cycle": entry.get("cycle"),
                 }
             )
             mp_comment = get_mp_comment(entry["Params"], mp_dat)
@@ -248,7 +325,11 @@ def get_page_entries(start_time):
     # Update the entries with defined weeks to have links to starcheck.
     for entry in entries:
         if "products" in entry:
+            entry["mp_url"] = (
+                f"https://icxc.harvard.edu/mp/schedules/cycle{entry["cycle"]}/{entry["products"]}.html"
+            )
             entry["starcheck_url"] = get_starcheck_url(entry["products"])
+            entry["fot_week_url"] = get_fot_week_url(entry["products"])
 
     # Sort by date
     entries.sort(key=lambda x: x["date"])

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -73,8 +73,6 @@ def get_mp_scheds(files):
 
     dat = []
     for sched_file in files:
-        # First I want to read the cycle name which can be found in the first <H1> tag
-        # like "<h1 align="center"> AO26 CXC Observing Schedules </h1>"
         tab = Table.read(sched_file, header_start=0, data_start=1)
         # If all the comments are empty or masked, replace with emtpy string
         if np.all(tab["Comment"].mask):


### PR DESCRIPTION
## Description

Include a link to the FOT version of products and break out the products links to match Tom's request/suggestion:

Idea for first column: [MAR2426A](https://icxc.harvard.edu/mp/schedules/cycle25/MAR2624A.html) [FOT](https://occweb.cfa.harvard.edu/occweb/FOT/mission_planning/PRODUCTS/APPR_LOADS/2024/MAR/MAR2624A/) [SC](https://icxc.harvard.edu/mp/mplogs/2024/MAR2624/oflsa/starcheck.html) (SOT MP load page on icxc, FOT load page on OCCweb, Starcheck on icxc)

(though I put them in different columns but still first part of the table)

This was slightly trickier than I'd anticipated because the request included linking to the SOT MP products page, which depends on "cycle" which is not trivially determined from week name.  However, since we are reading all of the SOT MP "cycle" pages in the interval anyway, we can remap week-to-cycle and use that in the data structures, so that's what this does.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
~
(ska3-latest) jeanconn-kady> git rev-parse HEAD
5ce51832d9d0e4c98612f29f75a922dc451c08b3
(ska3-latest) jeanconn-kady> ipython
Python 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:24:40) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.31.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: run schedule_view/schedule_view.py --outdir /proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/schedule_view3/pr7/
```
Demo/test output at https://icxc.cfa.harvard.edu/aspect/test_review_outputs/schedule_view3/pr7/ 