### PR TITLE
Write out a file that maps week name to MP cycle number

### DIFF
--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -22,11 +22,9 @@ def get_options():
 
 def get_sched_files():
     """
-    Get a list of the files with SOT MP schedules.
+    Get a list of the SOT MP schedules files to map cycle pages to schedule loads.
 
-    This tool is only useful for viewing schedules in the RLTT era, so
-    there's a small optimization that this only fetches files from cycle 20
-    on. This will only succeed on HEAD systems with access to /proj/web-icxc.
+    This will only succeed on HEAD systems with access to /proj/web-icxc.
 
     Returns
     -------
@@ -36,7 +34,8 @@ def get_sched_files():
     """
     files = []
     top_level = "/proj/web-icxc/htdocs/mp/html/"
-    for glob in ["schedules_ao2?.html", "schedules.html"]:
+    # Read everything starting with AO3 when these were made into html tables
+    for glob in ["schedules_ao[3-9].html", "schedules_ao[1-9]?.html", "schedules.html"]:
         sched_files = list(Path(top_level).glob(glob))
         sched_files.sort()
         files.extend(sched_files)
@@ -183,7 +182,7 @@ def get_starcheck_url(week):
     return f"https://icxc.harvard.edu/mp/mplogs{week_str}starcheck.html"
 
 
-def get_page_entries(start_time):
+def get_page_entries(start_time, mp_dat=None):
     """
     Get the entries for the schedule view page.
 
@@ -191,6 +190,9 @@ def get_page_entries(start_time):
     ----------
     start_time : CxoTime or compatible str
         The start time for the list of cmds and events to be considered.
+    mp_dat : astropy.table.Table, optional
+        Pre-computed table from get_mp_scheds. If not provided, it will be
+        fetched automatically.
 
     Returns
     -------
@@ -220,8 +222,9 @@ def get_page_entries(start_time):
     events_flight = events_flight[ok]
 
     # Get SOT MP comments and weeks
-    sched_files = get_sched_files()
-    mp_dat = get_mp_scheds(sched_files)
+    if mp_dat is None:
+        sched_files = get_sched_files()
+        mp_dat = get_mp_scheds(sched_files)
 
     # For the set of run loads, add a dictionary for each to a list of entries for the
     # output table. Check if there are command events / nonload commands between rltt and
@@ -328,11 +331,32 @@ def get_page_entries(start_time):
     return entries
 
 
+def write_cycle_map(mp_scheds, outfile):
+    """
+    Write a CSV mapping of cycle_number to Week and Version.
+
+    Parameters
+    ----------
+    mp_scheds : astropy.table.Table
+        The table of SOT MP schedules from get_mp_scheds.
+    outfile : str or Path
+        Output file path.
+    """
+    out = mp_scheds["cycle_number", "Week", "Version"].copy()
+    out["load_name"] = [w + v for w, v in zip(out["Week"], out["Version"])]
+    out = out["cycle_number", "load_name"]
+    out.write(outfile, format="csv", overwrite=True)
+
+
 def main(sys_argv=None):
     opt = get_options().parse_args(sys_argv)
     start_time = opt.start or "2020:110"
 
-    entries = get_page_entries(start_time)
+    sched_files = get_sched_files()
+    mp_dat = get_mp_scheds(sched_files)
+    write_cycle_map(mp_dat, Path(opt.outdir) / "cycle_map.csv")
+
+    entries = get_page_entries(start_time, mp_dat=mp_dat)
 
     # Make HTML
     template = Template(open(TEMPLATE).read())

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -356,6 +356,8 @@ def main(sys_argv=None):
 
     sched_files = get_sched_files()
     mp_dat = get_mp_scheds(sched_files)
+
+    Path(opt.outdir).mkdir(exist_ok=True, parents=True)
     write_cycle_map(mp_dat, Path(opt.outdir) / "cycle_map.csv")
 
     entries = get_page_entries(start_time, mp_dat=mp_dat)
@@ -366,7 +368,6 @@ def main(sys_argv=None):
         entries=entries[::-1],
     )
 
-    Path(opt.outdir).mkdir(exist_ok=True, parents=True)
     outfile = Path(opt.outdir) / "index.html"
 
     with open(outfile, "w") as fh:

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -59,6 +59,8 @@ def get_mp_scheds(files):
     """
 
     def extract_cycle_number(h1_text):
+        # Note that we've set the O optional for typos on the cycle 10 and 11 pages
+        # where the O is missing.
         match = re.search(r"AO?(\d+)", h1_text)
         if match:
             return match.group(1)
@@ -333,7 +335,7 @@ def get_page_entries(start_time, mp_dat=None):
 
 def write_cycle_map(mp_scheds, outfile):
     """
-    Write a CSV mapping of cycle_number to Week and Version.
+    Write a CSV mapping of load name to cycle number for the SOT MP schedules.
 
     Parameters
     ----------
@@ -343,6 +345,8 @@ def write_cycle_map(mp_scheds, outfile):
         Output file path.
     """
     out = mp_scheds["cycle_number", "Week", "Version"].copy()
+
+    # Filter these to just the entries where the version is a single letter.
     ok = [bool(re.match(r"^[A-Za-z]$", str(v))) for v in out["Version"]]
     out = out[ok]
     out["load_name"] = [w + v for w, v in zip(out["Week"], out["Version"])]

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -185,7 +185,7 @@ def get_starcheck_url(week):
     return f"https://icxc.harvard.edu/mp/mplogs{week_str}starcheck.html"
 
 
-def get_page_entries(start_time, mp_scheds=None):
+def get_page_entries(start_time, mp_scheds):
     """
     Get the entries for the schedule view page.
 
@@ -193,9 +193,8 @@ def get_page_entries(start_time, mp_scheds=None):
     ----------
     start_time : CxoTime or compatible str
         The start time for the list of cmds and events to be considered.
-    mp_dat : astropy.table.Table, optional
-        Pre-computed table from get_mp_scheds. If not provided, it will be
-        fetched automatically.
+    mp_scheds : astropy.table.Table
+        The table of SOT MP schedules from get_mp_scheds.
 
     Returns
     -------
@@ -223,11 +222,6 @@ def get_page_entries(start_time, mp_scheds=None):
     events_flight.rename_column("Date", "date")
     ok = events_flight["date"] > start_time
     events_flight = events_flight[ok]
-
-    # Get SOT MP comments and weeks
-    if mp_scheds is None:
-        sched_files = get_sched_files()
-        mp_scheds = get_mp_scheds(sched_files)
 
     # For the set of run loads, add a dictionary for each to a list of entries for the
     # output table. Check if there are command events / nonload commands between rltt and
@@ -361,7 +355,7 @@ def main(sys_argv=None):
     Path(opt.outdir).mkdir(exist_ok=True, parents=True)
     write_cycle_map(mp_scheds, Path(opt.outdir) / "cycle_map.json")
 
-    entries = get_page_entries(start_time, mp_scheds=mp_scheds)
+    entries = get_page_entries(start_time, mp_scheds)
 
     # Make HTML
     template = Template(open(TEMPLATE).read())

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -59,7 +59,7 @@ def get_mp_scheds(files):
     """
 
     def extract_cycle_number(h1_text):
-        match = re.search(r"AO(\d+)", h1_text)
+        match = re.search(r"AO?(\d+)", h1_text)
         if match:
             return match.group(1)
         return None

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -343,6 +343,8 @@ def write_cycle_map(mp_scheds, outfile):
         Output file path.
     """
     out = mp_scheds["cycle_number", "Week", "Version"].copy()
+    ok = [bool(re.match(r"^[A-Za-z]$", str(v))) for v in out["Version"]]
+    out = out[ok]
     out["load_name"] = [w + v for w, v in zip(out["Week"], out["Version"])]
     out = out["cycle_number", "load_name"]
     out.write(outfile, format="csv", overwrite=True)

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -346,8 +346,7 @@ def write_cycle_map(mp_scheds, outfile):
         Output file path.
     """
     cycle_map = {
-        week: int(cycle)
-        for week, cycle in zip(mp_scheds["Week"], mp_scheds["cycle_number"])
+        mp_sched["Week"]: int(mp_sched["cycle_number"]) for mp_sched in mp_scheds
     }
     Path(outfile).write_text(json.dumps(cycle_map, indent=2))
 

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -336,7 +336,7 @@ def get_page_entries(start_time, mp_scheds=None):
 
 def write_cycle_map(mp_scheds, outfile):
     """
-    Write a CSV mapping of load name to cycle number for the SOT MP schedules.
+    Write a JSON mapping of week name to cycle number for the SOT MP schedules.
 
     Parameters
     ----------
@@ -345,7 +345,10 @@ def write_cycle_map(mp_scheds, outfile):
     outfile : str or Path
         Output file path.
     """
-    cycle_map = dict(zip(mp_scheds["Week"], mp_scheds["cycle_number"].astype(int)))
+    cycle_map = {
+        week: int(cycle)
+        for week, cycle in zip(mp_scheds["Week"], mp_scheds["cycle_number"])
+    }
     Path(outfile).write_text(json.dumps(cycle_map, indent=2))
 
 

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -345,13 +345,7 @@ def write_cycle_map(mp_scheds, outfile):
     outfile : str or Path
         Output file path.
     """
-    out = mp_scheds["Week", "cycle_number"].copy()
-
-    # Filter these to just the unique week names
-    _, idx = np.unique(out["Week"], return_index=True)
-    out = out[idx]
-
-    cycle_map = dict(zip(out["Week"], out["cycle_number"]))
+    cycle_map = dict(zip(mp_scheds["Week"], mp_scheds["cycle_number"].astype(int)))
     Path(outfile).write_text(json.dumps(cycle_map, indent=2))
 
 

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import re
 from pathlib import Path
 
@@ -184,7 +185,7 @@ def get_starcheck_url(week):
     return f"https://icxc.harvard.edu/mp/mplogs{week_str}starcheck.html"
 
 
-def get_page_entries(start_time, mp_dat=None):
+def get_page_entries(start_time, mp_scheds=None):
     """
     Get the entries for the schedule view page.
 
@@ -224,9 +225,9 @@ def get_page_entries(start_time, mp_dat=None):
     events_flight = events_flight[ok]
 
     # Get SOT MP comments and weeks
-    if mp_dat is None:
+    if mp_scheds is None:
         sched_files = get_sched_files()
-        mp_dat = get_mp_scheds(sched_files)
+        mp_scheds = get_mp_scheds(sched_files)
 
     # For the set of run loads, add a dictionary for each to a list of entries for the
     # output table. Check if there are command events / nonload commands between rltt and
@@ -235,10 +236,10 @@ def get_page_entries(start_time, mp_dat=None):
     entries = []
     for week in run_loads:
         entry = {"products": week}
-        mp_comment = get_mp_comment(week, mp_dat)
+        mp_comment = get_mp_comment(week, mp_scheds)
         if mp_comment is not None:
             entry["mp_comment"] = mp_comment
-        entry["cycle"] = get_mp_cycle(week, mp_dat)
+        entry["cycle"] = get_mp_cycle(week, mp_scheds)
         cmds_week = cmds[cmds["source"] == week]
         rltt_cmd = cmds_week.get_rltt_cmd()
         if rltt_cmd is None:
@@ -292,10 +293,10 @@ def get_page_entries(start_time, mp_dat=None):
                     "products": entry["Params"],
                     "Event": entry["Event"],
                     "Comment": entry["Comment"],
-                    "cycle": get_mp_cycle(entry["Params"], mp_dat),
+                    "cycle": get_mp_cycle(entry["Params"], mp_scheds),
                 }
             )
-            mp_comment = get_mp_comment(entry["Params"], mp_dat)
+            mp_comment = get_mp_comment(entry["Params"], mp_scheds)
             if mp_comment is not None:
                 week_entry["mp_comment"] = mp_comment
             if not has_entry:
@@ -344,14 +345,14 @@ def write_cycle_map(mp_scheds, outfile):
     outfile : str or Path
         Output file path.
     """
-    out = mp_scheds["cycle_number", "Week", "Version"].copy()
+    out = mp_scheds["Week", "cycle_number"].copy()
 
-    # Filter these to just the entries where the version is a single letter.
-    ok = [bool(re.match(r"^[A-Za-z]$", str(v))) for v in out["Version"]]
-    out = out[ok]
-    out["load_name"] = [w + v for w, v in zip(out["Week"], out["Version"])]
-    out = out["load_name", "cycle_number"]
-    out.write(outfile, format="csv", overwrite=True)
+    # Filter these to just the unique week names
+    _, idx = np.unique(out["Week"], return_index=True)
+    out = out[idx]
+
+    cycle_map = dict(zip(out["Week"], out["cycle_number"]))
+    Path(outfile).write_text(json.dumps(cycle_map, indent=2))
 
 
 def main(sys_argv=None):
@@ -359,12 +360,12 @@ def main(sys_argv=None):
     start_time = opt.start or "2020:110"
 
     sched_files = get_sched_files()
-    mp_dat = get_mp_scheds(sched_files)
+    mp_scheds = get_mp_scheds(sched_files)
 
     Path(opt.outdir).mkdir(exist_ok=True, parents=True)
-    write_cycle_map(mp_dat, Path(opt.outdir) / "cycle_map.csv")
+    write_cycle_map(mp_scheds, Path(opt.outdir) / "cycle_map.json")
 
-    entries = get_page_entries(start_time, mp_dat=mp_dat)
+    entries = get_page_entries(start_time, mp_scheds=mp_scheds)
 
     # Make HTML
     template = Template(open(TEMPLATE).read())

--- a/schedule_view/schedule_view.py
+++ b/schedule_view/schedule_view.py
@@ -346,7 +346,7 @@ def write_cycle_map(mp_scheds, outfile):
     ok = [bool(re.match(r"^[A-Za-z]$", str(v))) for v in out["Version"]]
     out = out[ok]
     out["load_name"] = [w + v for w, v in zip(out["Week"], out["Version"])]
-    out = out["cycle_number", "load_name"]
+    out = out["load_name", "cycle_number"]
     out.write(outfile, format="csv", overwrite=True)
 
 


### PR DESCRIPTION
## Description

Write out a file that maps week name to MP cycle number.

The weeks are not versioned (JAN1215 vs JAN1215**B**) with the expectation that the mapping to cycle name won't change between versions.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #8 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I just ran "run schedule_view/schedule_view.py --outdir newtest" on head and the csv file out in newtest is attached: 

[cycle_map.json](https://github.com/user-attachments/files/26418594/cycle_map.json)

In this draft I just had it parse all the files that are in the current table form but this could be trimmed to be 2020 forward or whatever, obviously.  

I looked over the output file for formatting (missing cycle number) and it looks fine.  There's one week from SOT MP that ends in _R but I think we don't care about extras. I validated against the source names from kadi.commands and everything looks to match up except that in the MP schedule pages one load, JUL1309B, is missing.  It looks like that is also missing in APPR_LOADs so I think that was a mixup in the old database that has propagated forward into kadi cmds.
